### PR TITLE
[FEATURE] Add fake MFA provider

### DIFF
--- a/Classes/Authentication/Mfa/FakeMfaProvider.php
+++ b/Classes/Authentication/Mfa/FakeMfaProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DifferentTechnology\AzureAdBe\Authentication\Mfa;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderInterface;
+use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderPropertyManager;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\Response;
+
+class FakeMfaProvider implements MfaProviderInterface
+{
+	protected Context $context;
+
+	protected ServerRequestInterface $request;
+
+	public function __construct(Context $context)
+	{
+		$this->context = $context;
+	}
+
+	public function canProcess(ServerRequestInterface $request): bool
+	{
+		return true;
+	}
+
+	public function isActive(MfaProviderPropertyManager $propertyManager): bool
+	{
+		return (bool)$propertyManager->getProperty('active');
+	}
+
+	public function isLocked(MfaProviderPropertyManager $propertyManager): bool
+	{
+		return false;
+	}
+
+	public function handleRequest(
+		ServerRequestInterface $request,
+		MfaProviderPropertyManager $propertyManager,
+		string $type
+	): ResponseInterface {
+		return new Response();
+	}
+
+	public function verify(
+		ServerRequestInterface $request,
+		MfaProviderPropertyManager $propertyManager
+	): bool {
+		$properties['attempts'] = 0;
+		$properties['lastUsed'] = $this->context->getPropertyFromAspect('date', 'timestamp');
+
+		return $propertyManager->updateProperties($properties);
+	}
+
+	public function activate(
+		ServerRequestInterface $request,
+		MfaProviderPropertyManager $propertyManager
+	): bool {
+		return $this->update($request, $propertyManager);
+	}
+
+	public function unlock(
+		ServerRequestInterface $request,
+		MfaProviderPropertyManager $propertyManager
+	): bool {
+		if (
+			!$this->isActive($propertyManager)
+			|| !$this->isLocked($propertyManager)
+		) {
+			return false;
+		}
+
+		return $propertyManager->updateProperties(['attempts' => 0]);
+	}
+
+	public function deactivate(
+		ServerRequestInterface $request,
+		MfaProviderPropertyManager $propertyManager
+	): bool {
+		if (!$this->isActive($propertyManager)) {
+			return false;
+		}
+
+		return $propertyManager->updateProperties(['active' => false]);
+	}
+
+	public function update(
+		ServerRequestInterface $request,
+		MfaProviderPropertyManager $propertyManager
+	): bool {
+		if (!$this->canProcess($request)) {
+			return false;
+		}
+
+		$properties = [
+			'active' => true,
+		];
+
+		return $propertyManager->hasProviderEntry()
+			? $propertyManager->updateProperties($properties)
+			: $propertyManager->createProviderEntry($properties);
+	}
+}

--- a/Classes/Authentication/Mfa/FakeMfaProvider.php
+++ b/Classes/Authentication/Mfa/FakeMfaProvider.php
@@ -52,7 +52,9 @@ class FakeMfaProvider implements MfaProviderInterface
 		$properties['attempts'] = 0;
 		$properties['lastUsed'] = $this->context->getPropertyFromAspect('date', 'timestamp');
 
-		return $propertyManager->updateProperties($properties);
+		$propertyManager->updateProperties($properties);
+
+		return !empty($propertyManager->getUser()->user['tx_azure_ad_be_payload_user']);
 	}
 
 	public function activate(

--- a/Classes/Authentication/Mfa/FakeMfaProvider.php
+++ b/Classes/Authentication/Mfa/FakeMfaProvider.php
@@ -8,8 +8,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderInterface;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderPropertyManager;
+use TYPO3\CMS\Core\Authentication\Mfa\MfaViewType;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ResponseFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\View\StandaloneView;
 
 class FakeMfaProvider implements MfaProviderInterface
 {
@@ -17,9 +20,14 @@ class FakeMfaProvider implements MfaProviderInterface
 
 	protected ServerRequestInterface $request;
 
-	public function __construct(Context $context)
-	{
+	protected ResponseFactory $responseFactory;
+
+	public function __construct(
+		Context $context,
+		ResponseFactory $responseFactory
+	) {
 		$this->context = $context;
+		$this->responseFactory = $responseFactory;
 	}
 
 	public function canProcess(ServerRequestInterface $request): bool
@@ -42,7 +50,29 @@ class FakeMfaProvider implements MfaProviderInterface
 		MfaProviderPropertyManager $propertyManager,
 		string $type
 	): ResponseInterface {
-		return new Response();
+		$view = GeneralUtility::makeInstance(StandaloneView::class);
+		$view->setTemplateRootPaths(['EXT:azure_ad_be/Resources/Private/Templates/Mfa']);
+
+		switch ($type) {
+			case MfaViewType::SETUP:
+				$view->setTemplate('Setup');
+				break;
+			case MfaViewType::EDIT:
+				$view->setTemplate('Edit');
+				break;
+			case MfaViewType::AUTH:
+				$view->setTemplate('Auth');
+				break;
+		}
+
+		$response = $this->responseFactory->createResponse();
+		$response->getBody()->write(
+			$view
+				->assign('providerIdentifier', $propertyManager->getIdentifier())
+				->render()
+		);
+
+		return $response;
 	}
 
 	public function verify(

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,14 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  DifferentTechnology\AzureAdBe\Authentication\Mfa\FakeMfaProvider:
+    tags:
+      - name: mfa.provider
+        identifier: 'fake-mfa-provider'
+        title: 'LLL:EXT:azure_ad_be/Resources/Private/Language/locallang.xlf:fake-mfa-provider.title'
+        description: 'LLL:EXT:azure_ad_be/Resources/Private/Language/locallang.xlf:fake-mfa-provider.description'
+        setupInstructions: 'LLL:EXT:azure_ad_be/Resources/Private/Language/locallang.xlf:fake-mfa-provider.setupInstructions'
+        icon: 'actions-brand-windows'

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -15,6 +15,21 @@
       <trans-unit id="be_users.tx_azure_ad_be_payload_groups">
         <source>Azure Group JSON Payload</source>
       </trans-unit>
+
+			<!-- fake-mfa-provider -->
+      <trans-unit id="fake-mfa-provider.title">
+        <source>Azure Fake MFA Provider</source>
+      </trans-unit>
+      <trans-unit id="fake-mfa-provider.description">
+        <source>Azure Fake MFA Provider</source>
+      </trans-unit>
+      <trans-unit id="fake-mfa-provider.description">
+        <source>@todo description</source>
+      </trans-unit>
+      <trans-unit id="fake-mfa-provider.setupInstructions">
+        <source>@todo setupInstructions</source>
+      </trans-unit>
+
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Templates/Mfa/Auth.html
+++ b/Resources/Private/Templates/Mfa/Auth.html
@@ -1,0 +1,1 @@
+<p>@todo Auth</p>

--- a/Resources/Private/Templates/Mfa/Edit.html
+++ b/Resources/Private/Templates/Mfa/Edit.html
@@ -1,0 +1,1 @@
+<p>@todo Edit</p>

--- a/Resources/Private/Templates/Mfa/Setup.html
+++ b/Resources/Private/Templates/Mfa/Setup.html
@@ -1,0 +1,1 @@
+<p>@todo Setup</p>


### PR DESCRIPTION
Fixes #1 

## Content required before merge

### Title for MFA provider (used extensively)

<img width="349" alt="initial setup choice" src="https://github.com/user-attachments/assets/5e1307a2-c82c-4848-81b0-d380b970cb8d" />


### Description for provider (used in multiple places throughout BE)

<img width="1424" alt="be admin group access" src="https://github.com/user-attachments/assets/11bf41b2-a731-4923-88a1-299022b6bc2d" />


### Setup instructions & additional setup instructions (optional)

<img width="986" alt="initial setup info" src="https://github.com/user-attachments/assets/40605fef-b8d7-4794-9bfe-94121c5cc6f7" />

### Additional content when BE user edits their own MFA (optional)

<img width="505" alt="user edit mfa" src="https://github.com/user-attachments/assets/e3c0517e-ab73-487b-b325-45ac0386648d" />


### Content to be displayed before verification (optional, but necessary)

<img width="352" alt="user verify" src="https://github.com/user-attachments/assets/dd18b452-7138-41fa-9702-eb19aae312c7" />
